### PR TITLE
Only install if no newer version installed

### DIFF
--- a/lib/dist.js
+++ b/lib/dist.js
@@ -11,7 +11,7 @@ exports.isInstalled = function(cmp, dst, o) {
   if (cmp.type === 'widget') {
 
     // installed if target exists and version matches
-    return fs.existsSync(dst.trgPath) && require(path.join(dst.trgPath, 'widget.json')).version === dst.version;
+    return fs.existsSync(dst.trgPath) && require(path.join(dst.trgPath, 'widget.json')).version >= dst.version;
 
   } else {
 


### PR DESCRIPTION
Fixes the comparison from installed to distribution to compare version numbers. So if a later version of a module is installed then is available from Gittio then it will deem it installed.
