### PR TITLE
Feature native deps

### DIFF
--- a/lib/gittio.js
+++ b/lib/gittio.js
@@ -6,6 +6,7 @@ var _ = require('underscore'),
   dist = require('./dist'),
   exec = require('./exec'),
   fs = require('fs-extended'),
+  glob = require('glob'),
   logger = require('./logger'),
   path = require('path'),
   path = require('path'),
@@ -348,32 +349,49 @@ function _installSingle(o) {
           // add dependency
           _addDependency(cmp, dst, o);
 
-          // recursive widget dependencies
+          // search for module/widget dependencies
+          var dependencies = {};
+
           if (cmp.type === 'widget') {
+            // recursive widget dependencies
             var widget = fs.readJSONSync(path.join(dst.trgPath, 'widget.json'));
 
             // include our self-declared 'modules' dependencies
-            var dependencies = _.extend({}, widget.dependencies || {}, widget.modules || {});
+            dependencies = _.extend({}, widget.dependencies || {}, widget.modules || {});
 
-            if (_.size(dependencies) > 0) {
-              var tasks = _.pairs(dependencies).map(function(kv) {
-                var id = kv[0],
-                  version = kv[1];
+          } else if (cmp.type === 'module') {
+            // recursive module dependencies (reading from the temp)
+            var pkgs = glob.sync('*/*/*/package.json', {
+              cwd: path.join(tmpPath, dst.srcPath)
+            }).map(function (pkgPath) {
+              return fs.readJSONSync(pkgPath);
+            });
 
-                return function() {
-                  install(_.defaults({
-                    id: id,
-                    version: version
-                  }, o));
-                };
+            // merge all package.json#_nativeDependencies
+            pkgs.forEach(function (pkg) {
+              _.defaults(dependencies, pkg._nativeDependencies || pkg.nativeDependencies || {});
+            });
+          }
 
-              });
+          var tasks;
+          if (dependencies && (_.size(dependencies) > 0)) {
+            tasks = _.pairs(dependencies).map(function(kv) {
+              var id = kv[0],
+              version = kv[1];
 
-              // install dependencies
-              if (tasks.length > 0) {
-                async.parallel(tasks);
-              }
-            }
+              return function() {
+                install(_.defaults({
+                  id: id,
+                  version: version
+                }, o));
+              };
+
+            });
+          }
+
+          // install dependencies
+          if (tasks && (tasks.length > 0)) {
+            async.parallel(tasks);
           }
 
           // remove tmpPath

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chalk": "~0.4.0",
     "commander": "~2.1.0",
     "fs-extended": "~0.2.0",
+    "glob": "^4.3.1",
     "request": "~2.30.0",
     "rimraf": "~2.2.5",
     "semver": "^4.1.0",


### PR DESCRIPTION
This fixes #85.

Currently we don’t support `nativeDependencies` with platform dependent versions.

I’m thinking about the following forms.

**normal, platform independent:**

``` json
{ "nativeDependencies": { "net.iamyellow.tiws": "*" } }
```

**platform specific, one version:**

``` json
{ "nativeDependencies": { "net.iamyellow.tiws": { "ios": "*" } } }
```

**platform specific, multiple versions:**

``` json
{ "nativeDependencies": { "net.iamyellow.tiws": {
  "ios": "*",
  "android": "*"
} } }
```

If it’s ok for you I’ll implement it this way for widgets too.
